### PR TITLE
feat(docs): add example for simple chatbot with telemetry integration

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -1,5 +1,6 @@
 nav:
   - index.md
   - Getting Started
+  - Examples
   - Concepts
   - Development

--- a/docs/Examples/01-simple-chat-bot.md
+++ b/docs/Examples/01-simple-chat-bot.md
@@ -1,0 +1,39 @@
+# A Simple Chatbot
+
+This example creates a simple chat bot that you can converse with in the included UI, and keep track of the execution with open telemetry.
+
+### The QType File
+
+```yaml
+--8<-- "../examples/chat_with_telemetry.qtype.yaml"
+```
+
+You can download it [here](https://github.com/bazaarvoice/qtype/blob/main/examples/chat_with_telemetry.qtype.yaml).
+There is also a version for [AWS Bedrock](https://github.com/bazaarvoice/qtype/blob/main/examples/chat_with_telemetry_bedrock.qtype.yaml).
+
+### The Architecture 
+
+```mermaid
+--8<-- "Examples/chat_with_telemetry.mmd"
+```
+
+### Authorization
+
+You'll need an OpenAI key.
+Put it in a `.env` file, and name the variable `OPENAI_KEY`
+
+### Telemetry
+The code pushes telemetry to a sync on your local machine. Start `arize-phoenix` with:
+```bash
+phoenix serve
+```
+Before running.
+
+### Runing the App
+
+Just run:
+```bash
+qtype serve chat_with_telemetry.qtype.yaml
+```
+
+And you can opne thet chat at [http://localhost:8000/ui](http://localhost:8000/ui)

--- a/docs/Examples/chat_with_telemetry.mmd
+++ b/docs/Examples/chat_with_telemetry.mmd
@@ -1,0 +1,42 @@
+flowchart TD
+    subgraph APP ["📱 Application: hello_world"]
+        direction TB
+
+    subgraph FLOW_0 ["💬 Flow: chat_example
+A simple chat flow with OpenAI"]
+        direction LR
+        FLOW_0_START@{shape: circle, label: "▶️ Start"}
+        FLOW_0_S0@{shape: rounded, label: "✨ llm_inference_step"}
+        FLOW_0_START -->|user_message: ChatMessage'>| FLOW_0_S0
+    end
+
+    subgraph RESOURCES ["🔧 Shared Resources"]
+        direction LR
+        AUTH_OPENAI_AUTH@{shape: hex, label: "🔐 openai_auth\nAPI_KEY"}
+        MODEL_GPT_4@{shape: rounded, label: "✨ gpt-4 (openai)" }
+        MODEL_GPT_4 -.->|uses| AUTH_OPENAI_AUTH
+    end
+
+    subgraph TELEMETRY ["📊 Observability"]
+        direction TB
+        TEL_SINK@{shape: curv-trap, label: "📡 hello_world_telemetry\nhttp&colon;//localhost:6006/v1/traces"}
+    end
+
+    end
+
+    FLOW_0_S0 -.->|uses| MODEL_GPT_4
+    FLOW_0_S0 -.->|traces| TEL_SINK
+
+    %% Styling
+    classDef appBox fill:none,stroke:#495057,stroke-width:3px
+    classDef flowBox fill:#e1f5fe,stroke:#0277bd,stroke-width:2px
+    classDef llmNode fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    classDef modelNode fill:#e8f5e8,stroke:#2e7d32,stroke-width:2px
+    classDef authNode fill:#fff3e0,stroke:#ef6c00,stroke-width:2px
+    classDef telemetryNode fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    classDef resourceBox fill:#f5f5f5,stroke:#616161,stroke-width:1px
+
+    class APP appBox
+    class FLOW_0 flowBox
+    class RESOURCES resourceBox
+    class TELEMETRY telemetryNode


### PR DESCRIPTION
- Introduced a new example demonstrating a simple chatbot using OpenAI.
- Included details on QType file, architecture, authorization, telemetry, and app execution.
- Added Mermaid diagram for visual representation of the architecture.