### PR TITLE
refactor(types): remove unused error field from StepError model

### DIFF
--- a/qtype/interpreter/types.py
+++ b/qtype/interpreter/types.py
@@ -265,10 +265,7 @@ class ProgressCallback(Protocol):
 class StepError(BaseModel):
     """A structured error object attached to a failed FlowState."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     step_id: str
-    error: Exception
     error_message: str
     exception_type: str
 
@@ -307,7 +304,6 @@ class FlowMessage(BaseModel):
         if not self.is_failed():  # Only capture the first error
             self.error = StepError(
                 step_id=step_id,
-                error=exc,
                 error_message=str(exc),
                 exception_type=type(exc).__name__,
             )

--- a/qtype/interpreter/typing.py
+++ b/qtype/interpreter/typing.py
@@ -118,8 +118,8 @@ def flow_results_to_output_container(
     outputs = []
     errors = []
     for m in messages:
-        if m.is_failed():
-            errors.append(m.error)
+        if m.is_failed() and m.error is not None:
+            errors.append(m.error.model_dump())
         else:
             output_instance = output_shape(**m.variables)
             outputs.append(output_instance.model_dump())


### PR DESCRIPTION
- Simplified the StepError model by removing the `error` field.
- Updated FlowMessage to handle errors more effectively by checking for `None`.

## Description / purpose of change(s):

fixes https://github.com/bazaarvoice/qtype/issues/58 
