### PR TITLE
refactor(flow): update input handling for Complete flows

### DIFF
--- a/examples/hello_world.qtype.yaml
+++ b/examples/hello_world.qtype.yaml
@@ -11,23 +11,25 @@ models:
 flows:
   - type: Flow
     id: simple_example
+    interface: 
+      type: Complete
     variables:
-      - id: prompt
+      - id: question
         type: text
       - id: formatted_prompt
         type: text
       - id: answer
         type: text
     inputs:
-      - prompt
+      - question
     outputs:
       - answer
     steps:
       - id: question_prompt
         type: PromptTemplate
-        template: "You are a helpful assistant. Answer the following question:\n{prompt}\n"
+        template: "You are a helpful assistant. Answer the following question:\n{question}\n"
         inputs:
-          - prompt
+          - question
         outputs:
           - formatted_prompt
       - id: llm_inference_step

--- a/examples/simple_agent.qtype.yaml
+++ b/examples/simple_agent.qtype.yaml
@@ -41,6 +41,6 @@ flows:
           - user_message
         outputs:
           - response
-# telemetry:
-#   id: simple_agent_telemetry
-#   endpoint: http://localhost:6006/v1/traces
+telemetry:
+  id: simple_agent_telemetry
+  endpoint: http://localhost:6006/v1/traces

--- a/qtype/semantic/checker.py
+++ b/qtype/semantic/checker.py
@@ -387,12 +387,9 @@ def _validate_flow(flow: Flow) -> None:
                 )
 
         elif flow.interface.type == "Complete":
-            # ensure there is one input called "prompt" and it is text
-            # TODO: relax this constraint to only be one input type text and map it to "prompt" from the vercel input shape in the api
+            # ensure there is one input and it is text
             prompt_input = [
-                i
-                for i in flow.inputs
-                if i.type == PrimitiveTypeEnum.text and i.id == "prompt"
+                i for i in flow.inputs if i.type == PrimitiveTypeEnum.text
             ]
             if len(prompt_input) != 1:
                 raise QTypeSemanticError(


### PR DESCRIPTION
- Changed input variable from `prompt` to `question` in hello_world example.
- Moved telemetry configuration from comment to active code in simple_agent example.
- Adjusted completion request mapping to dynamically handle input fields in ui_request_to_domain_type.py.
- Relaxed input validation in checker.py to allow any single text input for Complete flows.

Resolves https://github.com/bazaarvoice/qtype/issues/67

https://github.com/user-attachments/assets/a5b8a187-c2af-4f9e-9cf9-c6b0e74f6173

